### PR TITLE
🧱 Add support for custom chainIDs

### DIFF
--- a/packages/core/src/constants/type/Config.ts
+++ b/packages/core/src/constants/type/Config.ts
@@ -1,4 +1,4 @@
-import { ChainId, Chain } from '../../constants'
+import { Chain } from '../../constants'
 
 export type NodeUrls = {
   [chainId: number]: string
@@ -9,7 +9,7 @@ export type MulticallAddresses = {
 }
 
 export type FullConfig = {
-  readOnlyChainId?: ChainId
+  readOnlyChainId?: number
   readOnlyUrls?: NodeUrls
   multicallAddresses?: MulticallAddresses
   multicallVersion: 1 | 2

--- a/packages/core/src/hooks/useEthers.ts
+++ b/packages/core/src/hooks/useEthers.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { ChainId } from '../constants'
 import { useInjectedNetwork, useNetwork } from '../providers'
 import { EventEmitter } from 'events'
 
@@ -14,7 +13,7 @@ export type Web3Ethers = {
   setError: (error: Error) => void
   deactivate: () => void
   connector: undefined
-  chainId?: ChainId
+  chainId?: number
   account?: null | string
   error?: Error
   library?: JsonRpcProvider

--- a/packages/core/src/hooks/useTokenList.ts
+++ b/packages/core/src/hooks/useTokenList.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import { TokenInfo } from '@uniswap/token-lists'
-import { ChainId } from '../constants'
 import { useEthers } from './useEthers'
 
 interface TokenList {
@@ -9,7 +8,7 @@ interface TokenList {
   tokens: TokenInfo[]
 }
 
-export function useTokenList(tokenListURI: string, overrideChainId?: ChainId, tags?: string[]) {
+export function useTokenList(tokenListURI: string, overrideChainId?: number, tags?: string[]) {
   const { chainId: providerChainId } = useEthers()
   const [tokenList, setTokenList] = useState<TokenList>()
 

--- a/packages/core/src/model/Currency.ts
+++ b/packages/core/src/model/Currency.ts
@@ -1,4 +1,3 @@
-import { ChainId } from '../constants'
 import { CurrencyFormatOptions, DEFAULT_OPTIONS, formatCurrency } from './formatting'
 
 export class Currency {
@@ -32,7 +31,7 @@ export class NativeCurrency extends Currency {
   constructor(
     name: string,
     ticker: string,
-    readonly chainId: ChainId,
+    readonly chainId: number,
     decimals = 18,
     formattingOptions: Partial<CurrencyFormatOptions> = {}
   ) {
@@ -48,7 +47,7 @@ export class Token extends Currency {
   constructor(
     name: string,
     ticker: string,
-    readonly chainId: ChainId,
+    readonly chainId: number,
     readonly address: string,
     decimals = 18,
     formattingOptions: Partial<CurrencyFormatOptions> = {}

--- a/packages/core/src/model/TransactionStatus.ts
+++ b/packages/core/src/model/TransactionStatus.ts
@@ -1,4 +1,3 @@
-import { ChainId } from '../constants'
 import { TransactionResponse, TransactionReceipt } from '@ethersproject/abstract-provider'
 
 export type TransactionState = 'None' | 'PendingSignature' | 'Mining' | 'Success' | 'Fail' | 'Exception'
@@ -7,7 +6,7 @@ export interface TransactionStatus {
   status: TransactionState
   transaction?: TransactionResponse
   receipt?: TransactionReceipt
-  chainId?: ChainId
+  chainId?: number
   errorMessage?: string
   originalTransaction?: TransactionResponse
 }

--- a/packages/core/src/providers/devtools.ts
+++ b/packages/core/src/providers/devtools.ts
@@ -1,4 +1,3 @@
-import { ChainId } from '../constants'
 import { RawCall, ChainState } from './chainState'
 
 // NOTE: If you modify this file please ensure consistency with
@@ -10,13 +9,13 @@ interface Init {
 
 interface NetworkChanged {
   type: 'NETWORK_CHANGED'
-  chainId?: ChainId
+  chainId?: number
   multicallAddress?: string
 }
 
 interface BlockNumberChanged {
   type: 'BLOCK_NUMBER_CHANGED'
-  chainId: ChainId
+  chainId: number
   blockNumber: number
 }
 
@@ -27,7 +26,7 @@ interface AccountChanged {
 
 interface CallsChanged {
   type: 'CALLS_CHANGED'
-  chainId?: ChainId
+  chainId?: number
   calls: RawCall[]
 }
 
@@ -35,7 +34,7 @@ interface MulticallSuccess {
   type: 'MULTICALL_SUCCESS'
   multicallAddress: string
   duration: number
-  chainId: ChainId
+  chainId: number
   blockNumber: number
   state: ChainState
 }
@@ -45,7 +44,7 @@ interface MulticallError {
   multicallAddress: string
   duration: number
   calls: RawCall[]
-  chainId: ChainId
+  chainId: number
   blockNumber: number
   error: any
 }

--- a/packages/core/src/providers/network/model.ts
+++ b/packages/core/src/providers/network/model.ts
@@ -1,9 +1,8 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { ChainId } from '../../constants'
 
 export interface Network {
   provider?: JsonRpcProvider
-  chainId?: ChainId
+  chainId?: number
   accounts: string[]
   errors: Error[]
 }

--- a/packages/core/src/providers/notifications/model.ts
+++ b/packages/core/src/providers/notifications/model.ts
@@ -1,5 +1,4 @@
 import { TransactionReceipt, TransactionResponse } from '@ethersproject/abstract-provider'
-import { ChainId } from '../../constants'
 
 type NotificationPayload = { submittedAt: number } & (
   | { type: 'transactionStarted'; transaction: TransactionResponse; transactionName?: string }
@@ -23,17 +22,17 @@ type NotificationPayload = { submittedAt: number } & (
 export type Notification = { id: string } & NotificationPayload
 
 export type AddNotificationPayload = {
-  chainId: ChainId
+  chainId: number
   notification: NotificationPayload
 }
 
 export type RemoveNotificationPayload = {
-  chainId: ChainId
+  chainId: number
   notificationId: string
 }
 
 export type Notifications = {
-  [T in ChainId]?: Notification[]
+  [chainID: number]: Notification[]
 }
 
 export const DEFAULT_NOTIFICATIONS: Notifications = {}

--- a/packages/core/src/providers/notifications/reducer.ts
+++ b/packages/core/src/providers/notifications/reducer.ts
@@ -1,15 +1,14 @@
-import { ChainId } from '../../constants'
 import { Notification, Notifications } from './model'
 
 interface AddNotification {
   type: 'ADD_NOTIFICATION'
-  chainId: ChainId
+  chainId: number
   notification: Notification
 }
 
 interface RemoveNotification {
   type: 'REMOVE_NOTIFICATION'
-  chainId: ChainId
+  chainId: number
   notificationId: string
 }
 

--- a/packages/core/src/providers/transactions/model.ts
+++ b/packages/core/src/providers/transactions/model.ts
@@ -1,5 +1,4 @@
 import { TransactionReceipt, TransactionResponse } from '@ethersproject/providers'
-import { ChainId } from '../../constants'
 
 export interface StoredTransaction {
   transaction: TransactionResponse
@@ -18,7 +17,7 @@ export function getStoredTransactionState(transaction: StoredTransaction) {
 }
 
 export type StoredTransactions = {
-  [T in ChainId]?: StoredTransaction[]
+  [chainID: number]: StoredTransaction[]
 }
 
 export const DEFAULT_STORED_TRANSACTIONS: StoredTransactions = {}

--- a/packages/core/src/providers/transactions/reducer.ts
+++ b/packages/core/src/providers/transactions/reducer.ts
@@ -1,5 +1,3 @@
-import { ChainId } from '../../constants'
-
 import { StoredTransaction, StoredTransactions } from './model'
 
 type Action = AddTransaction | UpdateTransactions
@@ -10,26 +8,17 @@ interface AddTransaction {
 }
 interface UpdateTransactions {
   type: 'UPDATE_TRANSACTIONS'
-  chainId: ChainId
+  chainId: number
   transactions: StoredTransaction[]
-}
-
-function isChainId(chainId: number): chainId is ChainId {
-  return Object.values(ChainId).includes(chainId)
 }
 
 export function transactionReducer(state: StoredTransactions, action: Action): StoredTransactions {
   switch (action.type) {
     case 'ADD_TRANSACTION': {
       const { chainId } = action.payload.transaction
-
-      if (isChainId(chainId)) {
-        return {
-          ...state,
-          [chainId]: [action.payload, ...(state[chainId] ?? [])],
-        }
-      } else {
-        throw TypeError('Unsupported chain')
+      return {
+        ...state,
+        [chainId]: [action.payload, ...(state[chainId] ?? [])],
       }
     }
     case 'UPDATE_TRANSACTIONS':


### PR DESCRIPTION
This PR removes the constraint that chainIDs be a member of the chainID enum. Instead, chainIDs are treated as type `number` in most situations.

Addresses https://github.com/EthWorks/useDApp/issues/482