### PR TITLE
🔧 Fix ESLint relative directories

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "project": "./tsconfig.json",
     "sourceType": "module"
   },
+  "ignorePatterns": [".eslintrc.js"],
   "rules": {
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-explicit-any": "off",

--- a/packages/coingecko/.eslintrc.js
+++ b/packages/coingecko/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [`${__dirname}/../../.eslintrc.json`],
+}

--- a/packages/coingecko/.eslintrc.json
+++ b/packages/coingecko/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "../../.eslintrc.json"
-  ]
-}

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [`${__dirname}/../../.eslintrc.json`, 'plugin:react-hooks/recommended'],
+}

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "../../.eslintrc.json",
-    "plugin:react-hooks/recommended"
-  ]
-}

--- a/packages/example/.eslintrc.js
+++ b/packages/example/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [`${__dirname}/../../.eslintrc.json`],
+}

--- a/packages/example/.eslintrc.json
+++ b/packages/example/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "../../.eslintrc.json"
-  ]
-}

--- a/packages/extension/.eslintrc.js
+++ b/packages/extension/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [`${__dirname}/../../.eslintrc.json`],
+}

--- a/packages/extension/.eslintrc.json
+++ b/packages/extension/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["../../.eslintrc.json"]
-}

--- a/packages/testing/.eslintrc.js
+++ b/packages/testing/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [`${__dirname}/../../.eslintrc.json`],
+}

--- a/packages/testing/.eslintrc.json
+++ b/packages/testing/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "../../.eslintrc.json"
-  ]
-}


### PR DESCRIPTION
When I CTRL+click into a definition of a useDApp type in VS Code, an ESLint plugin error pops up to say that it cannot resolve the eslint config at `../../.eslintrc.json`. 

<img width="451" alt="Screenshot 2022-03-11 at 00 16 43" src="https://user-images.githubusercontent.com/89424366/157777318-ee45466e-c745-4ed6-ab69-06fd45568aa2.png">

This is because the eslint configs are not defined relative to the packages. This PR solves that.