### PR TITLE
👮 If a user tries to connect to an unsupported chain an error value will be returned by useEthers.

### DIFF
--- a/packages/core/src/hooks/useEthers.ts
+++ b/packages/core/src/hooks/useEthers.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { ExternalProvider, JsonRpcProvider } from '@ethersproject/providers'
-import { useInjectedNetwork, useNetwork } from '../providers'
+import { useConfig, useInjectedNetwork, useNetwork } from '../providers'
 import { useLocalStorage } from './useLocalStorage'
 
 type MaybePromise<T> = Promise<T> | any
@@ -38,6 +38,13 @@ export function useEthers(): Web3Ethers {
   const { injectedProvider, connect } = useInjectedNetwork()
   const [, setShouldConnectMetamask] = useLocalStorage('shouldConnectMetamask')
 
+  const { networks } = useConfig()
+  const supportedChainIds = networks?.map((network) => network.chainId)
+  const isUnsupportedChainId = chainId && supportedChainIds && supportedChainIds.indexOf(chainId) < 0
+  const unsupportedChainIdError = new Error("Unsupported chain id: " + chainId + ". Supported chain ids are: " + supportedChainIds + ".")
+  unsupportedChainIdError.name = "UnsupportedChainIdError"
+  const error = isUnsupportedChainId ? unsupportedChainIdError : errors[errors.length - 1]
+
   const result = {
     connector: undefined,
     library: provider,
@@ -61,7 +68,7 @@ export function useEthers(): Web3Ethers {
       throw new Error('setError is deprecated')
     },
 
-    error: errors[errors.length - 1],
+    error: error,
   }
 
   const activateBrowserWallet = useCallback(async () => {

--- a/packages/core/src/hooks/useEthers.ts
+++ b/packages/core/src/hooks/useEthers.ts
@@ -70,7 +70,7 @@ export function useEthers(): Web3Ethers {
       throw new Error('setError is deprecated')
     },
 
-    error: error,
+    error,
   }
 
   const activateBrowserWallet = useCallback(async () => {

--- a/packages/core/src/hooks/useEthers.ts
+++ b/packages/core/src/hooks/useEthers.ts
@@ -40,10 +40,19 @@ export function useEthers(): Web3Ethers {
 
   const { networks } = useConfig()
   const supportedChainIds = networks?.map((network) => network.chainId)
-  const isUnsupportedChainId = chainId && supportedChainIds && supportedChainIds.indexOf(chainId) < 0
-  const unsupportedChainIdError = new Error("Unsupported chain id: " + chainId + ". Supported chain ids are: " + supportedChainIds + ".")
+  const isUnsupportedChainId =
+    chainId && supportedChainIds && supportedChainIds.indexOf(chainId) < 0
+  const unsupportedChainIdError = new Error(
+    "Unsupported chain id: " +
+    chainId +
+    ". Supported chain ids are: " +
+    supportedChainIds +
+    "."
+  )
   unsupportedChainIdError.name = "UnsupportedChainIdError"
-  const error = isUnsupportedChainId ? unsupportedChainIdError : errors[errors.length - 1]
+  const error = isUnsupportedChainId
+    ? unsupportedChainIdError
+    : errors[errors.length - 1]
 
   const result = {
     connector: undefined,

--- a/packages/core/src/hooks/useEthers.ts
+++ b/packages/core/src/hooks/useEthers.ts
@@ -40,15 +40,12 @@ export function useEthers(): Web3Ethers {
 
   const { networks } = useConfig()
   const supportedChainIds = networks?.map((network) => network.chainId)
-  const isUnsupportedChainId =
-    chainId && supportedChainIds && supportedChainIds.indexOf(chainId) < 0
+  const isUnsupportedChainId = chainId && supportedChainIds && supportedChainIds.indexOf(chainId) < 0
   const unsupportedChainIdError = new Error(
     `Unsupported chain id: ${chainId}. Supported chain ids are: ${supportedChainIds}.`
   )
-  unsupportedChainIdError.name = "UnsupportedChainIdError"
-  const error = isUnsupportedChainId
-    ? unsupportedChainIdError
-    : errors[errors.length - 1]
+  unsupportedChainIdError.name = 'UnsupportedChainIdError'
+  const error = isUnsupportedChainId ? unsupportedChainIdError : errors[errors.length - 1]
 
   const result = {
     connector: undefined,

--- a/packages/core/src/hooks/useEthers.ts
+++ b/packages/core/src/hooks/useEthers.ts
@@ -48,7 +48,7 @@ export function useEthers(): Web3Ethers {
   const result = {
     connector: undefined,
     library: provider,
-    chainId,
+    chainId: isUnsupportedChainId ? undefined : chainId,
     account: accounts[0],
     active: !!provider,
     activate: async (providerOrConnector: SupportedProviders) => {

--- a/packages/core/src/hooks/useEthers.ts
+++ b/packages/core/src/hooks/useEthers.ts
@@ -43,11 +43,7 @@ export function useEthers(): Web3Ethers {
   const isUnsupportedChainId =
     chainId && supportedChainIds && supportedChainIds.indexOf(chainId) < 0
   const unsupportedChainIdError = new Error(
-    "Unsupported chain id: " +
-    chainId +
-    ". Supported chain ids are: " +
-    supportedChainIds +
-    "."
+    `Unsupported chain id: ${chainId}. Supported chain ids are: ${supportedChainIds}.`
   )
   unsupportedChainIdError.name = "UnsupportedChainIdError"
   const error = isUnsupportedChainId


### PR DESCRIPTION
In the documentation: 
```
networks List of intended supported chain configs. If a user tries to connect to an unsupported chain an error value will be returned by useEthers.
```
https://usedapp.readthedocs.io/en/latest/core.html?highlight=config#config
But in current version no `error` is returned.
So i added the code.
And it is consistent with the version before 0.9.1. When an `error` is returned, the chainId is returned as `undefined`.