### PR TITLE
🔥 Updated useTransaction status values

### DIFF
--- a/packages/docs/docs/core.mdx
+++ b/packages/docs/docs/core.mdx
@@ -873,7 +873,7 @@ Fields:
 - **PendingSignature** - when a transaction has been initiated, but requires signature.
 - **Mining** - when a transaction is sent to the network, but not yet mined. In this state ``transaction: TransactionResponse`` is available.
 - **Success** - when a transaction has been mined successfully. In this state ``transaction: TransactionResponse`` and ``receipt: TransactionReceipt`` are available.
-- **Failed** - when a transaction has been mined, but ended up reverted. Again ``transaction: TransactionResponse`` and ``receipt: TransactionReceipt`` are available.
+- **Fail** - when a transaction has been mined, but ended up reverted. Again ``transaction: TransactionResponse`` and ``receipt: TransactionReceipt`` are available.
 - **Exception** - when a transaction hasn't started, due to the exception that was thrown before the transaction was propagated to the network. The exception can come from application/library code (e.g. unexpected exception like malformed arguments) or externally (e.g user discarded transaction in Metamask). In this state the ``errorMessage: string`` is available (as well as exception object).
 
 Additionally all states except ``None``, contain ``chainId: ChainId``.


### PR DESCRIPTION
current version of useTransaction uses 'Fail' as tx status, instead of 'Failed'