### PR TITLE
🔧 Add .eslintrc.js to .npmignore

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -2,3 +2,4 @@ dist/**/test/
 test/
 dist/**/tsconfig.tsbuildinfo
 CHANGELOG.md
+.eslintrc.js


### PR DESCRIPTION
I previously thought I solved an issue with the VSCode ESLint plugin before with PR #568.

This however is actually the correct solution. There should be no need for the .eslintrc.js file to be in a published package.