### PR TITLE
📙 Read-only example, without browser wallet

### DIFF
--- a/.changeset/famous-badgers-wave.md
+++ b/.changeset/famous-badgers-wave.md
@@ -1,0 +1,6 @@
+---
+'@usedapp/core': patch
+'docs': patch
+---
+
+Correctly read `chainId` in read-only mode without browser wallet

--- a/packages/core/src/hooks/useChainState.ts
+++ b/packages/core/src/hooks/useChainState.ts
@@ -1,14 +1,15 @@
 import { useContext } from 'react'
 import { QueryParams } from '../constants/type/QueryParams'
-import { Action, MultiChainStatesContext, SingleChainState, useNetwork } from '../providers'
+import { Action, MultiChainStatesContext, SingleChainState, useConfig, useNetwork } from '../providers'
 
 export function useChainState(
   queryParams: QueryParams = {}
 ): (Partial<SingleChainState> & { dispatchCalls: (action: Action) => void }) | undefined {
   const multiChainState = useContext(MultiChainStatesContext)
+  const { readOnlyChainId } = useConfig()
 
   const { network } = useNetwork()
-  const chainId = queryParams.chainId ?? network.chainId
+  const chainId = queryParams.chainId ?? network.chainId ?? readOnlyChainId
 
   if (chainId === undefined) {
     return undefined

--- a/packages/docs/docs/01-Getting Started/02-Reading.mdx
+++ b/packages/docs/docs/01-Getting Started/02-Reading.mdx
@@ -34,3 +34,11 @@ import TokenBalance from '../../example-loader.js!/src/examples/TokenBalance.tsx
 ## Custom Hooks
 
 See the [Custom Hooks](/docs/Guides/Reading/Custom%20Hooks) guide if you need to read state not supported by the built-in [hooks](/docs/API%20Reference/Hooks).
+
+## Reading without a browser wallet
+
+In order to interact with the blockchain in a read-only mode without a browser wallet, use the `activate` function with your provider.
+
+import ReadingWithoutWallet from '../../example-loader.js!/src/examples/ReadingWithoutWallet.tsx'
+
+<ExampleContainer example={ReadingWithoutWallet}/>

--- a/packages/docs/docs/01-Getting Started/02-Reading.mdx
+++ b/packages/docs/docs/01-Getting Started/02-Reading.mdx
@@ -37,7 +37,7 @@ See the [Custom Hooks](/docs/Guides/Reading/Custom%20Hooks) guide if you need to
 
 ## Reading without a browser wallet
 
-In order to interact with the blockchain in a read-only mode without a browser wallet, use the `activate` function with your provider.
+In order to interact with the blockchain in a read-only mode without a browser wallet, just specify `readOnlyChainId` and `readOnlyUrls` in your config - no activation required.
 
 import ReadingWithoutWallet from '../../example-loader.js!/src/examples/ReadingWithoutWallet.tsx'
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -24,6 +24,7 @@
     "@docusaurus/preset-classic": "2.0.0-beta.17",
     "@docusaurus/remark-plugin-npm2yarn": "^2.0.0-beta.17",
     "@ethersproject/contracts": "5.6.0",
+    "@ethersproject/providers": "5.6.0",
     "@ethersproject/units": "5.6.0",
     "@mdx-js/react": "^1.6.22",
     "@usedapp/coingecko": "workspace:^0.4.4",

--- a/packages/docs/src/examples/GettingStarted.tsx
+++ b/packages/docs/src/examples/GettingStarted.tsx
@@ -14,7 +14,7 @@ import { getDefaultProvider } from 'ethers'
 const config: Config = {
   readOnlyChainId: Mainnet.chainId,
   readOnlyUrls: {
-    [Mainnet.chainId]: getDefaultProvider(),
+    [Mainnet.chainId]: getDefaultProvider('mainnet'),
   },
 }
 

--- a/packages/docs/src/examples/ReadingWithoutWallet.tsx
+++ b/packages/docs/src/examples/ReadingWithoutWallet.tsx
@@ -1,0 +1,31 @@
+import { formatEther } from '@ethersproject/units'
+import { Config, DAppProvider, Mainnet, useEtherBalance } from '@usedapp/core'
+import { getDefaultProvider } from 'ethers'
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+const STAKING_CONTRACT = '0x00000000219ab540356cBB839Cbe05303d7705Fa'
+
+const config: Config = {
+    readOnlyChainId: Mainnet.chainId,
+    readOnlyUrls: {
+      [Mainnet.chainId]: getDefaultProvider('mainnet'),
+    },
+}
+
+ReactDOM.render(
+    <DAppProvider config={config}>
+      <App />
+    </DAppProvider>,
+    document.getElementById('root')
+)
+
+export function App() {
+  const etherBalance = useEtherBalance(STAKING_CONTRACT)
+
+  return (
+    <div>
+      {etherBalance && <p>Ether balance: {formatEther(etherBalance)}</p>}
+    </div>
+  )
+}

--- a/packages/docs/src/examples/SendTransaction.tsx
+++ b/packages/docs/src/examples/SendTransaction.tsx
@@ -6,7 +6,7 @@ import { getDefaultProvider } from 'ethers'
 const config: Config = {
     readOnlyChainId: Mainnet.chainId,
     readOnlyUrls: {
-      [Mainnet.chainId]: getDefaultProvider,
+      [Mainnet.chainId]: getDefaultProvider('mainnet'),
     },
 }
 

--- a/packages/docs/src/examples/TokenBalance.tsx
+++ b/packages/docs/src/examples/TokenBalance.tsx
@@ -9,7 +9,7 @@ const DAI = '0x6b175474e89094c44da98b954eedeac495271d0f'
 const config: Config = {
     readOnlyChainId: Mainnet.chainId,
     readOnlyUrls: {
-      [Mainnet.chainId]: getDefaultProvider,
+      [Mainnet.chainId]: getDefaultProvider('mainnet'),
     },
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,7 @@ importers:
       '@docusaurus/preset-classic': 2.0.0-beta.17
       '@docusaurus/remark-plugin-npm2yarn': ^2.0.0-beta.17
       '@ethersproject/contracts': 5.6.0
+      '@ethersproject/providers': 5.6.0
       '@ethersproject/units': 5.6.0
       '@mdx-js/react': ^1.6.22
       '@tsconfig/docusaurus': ^1.0.4
@@ -179,6 +180,7 @@ importers:
       '@docusaurus/preset-classic': 2.0.0-beta.17_881404fbc54bd1a20a9902f0565537a5
       '@docusaurus/remark-plugin-npm2yarn': 2.0.0-beta.17
       '@ethersproject/contracts': 5.6.0
+      '@ethersproject/providers': 5.6.0
       '@ethersproject/units': 5.6.0
       '@mdx-js/react': 1.6.22_react@17.0.2
       '@usedapp/coingecko': link:../coingecko
@@ -21397,7 +21399,7 @@ packages:
       lodash: 4.17.21
       opener: 1.5.2
       sirv: 1.0.19
-      ws: 7.4.6
+      ws: 7.5.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate


### PR DESCRIPTION
- Fix a bug with read-only `chainId`
- Explicit `mainnet` default provider
- Example of read-only without browser wallet