### PR TITLE
🍜 Refactor: Extract `chainId` resolution to a hook

### DIFF
--- a/packages/core/src/hooks/useBlockMeta.ts
+++ b/packages/core/src/hooks/useBlockMeta.ts
@@ -13,7 +13,7 @@ const GET_CURRENT_BLOCK_DIFFICULTY_CALL = MultiCallABI.encodeFunctionData('getCu
  * @public
  */
 export function useBlockMeta(queryParams: QueryParams = {}) {
-  const chainId = useChainId({queryParams})
+  const chainId = useChainId({ queryParams })
 
   const address = useMulticallAddress(queryParams)
   const timestamp = useRawCall(

--- a/packages/core/src/hooks/useBlockMeta.ts
+++ b/packages/core/src/hooks/useBlockMeta.ts
@@ -2,8 +2,8 @@ import { MultiCallABI } from '../constants'
 import { BigNumber } from '@ethersproject/bignumber'
 import { useMulticallAddress } from './useMulticallAddress'
 import { QueryParams } from '../constants/type/QueryParams'
-import { useConfig, useNetwork } from '../providers'
 import { useRawCall } from './useRawCalls'
+import { useChainId } from './useChainId'
 
 const GET_CURRENT_BLOCK_TIMESTAMP_CALL = MultiCallABI.encodeFunctionData('getCurrentBlockTimestamp', [])
 const GET_CURRENT_BLOCK_DIFFICULTY_CALL = MultiCallABI.encodeFunctionData('getCurrentBlockDifficulty', [])
@@ -13,9 +13,7 @@ const GET_CURRENT_BLOCK_DIFFICULTY_CALL = MultiCallABI.encodeFunctionData('getCu
  * @public
  */
 export function useBlockMeta(queryParams: QueryParams = {}) {
-  const { network } = useNetwork()
-  const { readOnlyChainId } = useConfig()
-  const chainId = queryParams.chainId ?? network.chainId ?? readOnlyChainId
+  const chainId = useChainId({queryParams})
 
   const address = useMulticallAddress(queryParams)
   const timestamp = useRawCall(

--- a/packages/core/src/hooks/useCall.ts
+++ b/packages/core/src/hooks/useCall.ts
@@ -44,7 +44,7 @@ export function useCall<T extends TypedContract, MN extends ContractMethodNames<
  * @returns a list of results (see {@link CallResult} in {@link useCall} above).
  */
 export function useCalls(calls: (Call | Falsy)[], queryParams: QueryParams = {}): CallResult<Contract, string>[] {
-  const chainId = useChainId({queryParams})
+  const chainId = useChainId({ queryParams })
 
   const rawCalls = calls.map((call) => (chainId !== undefined ? encodeCallData(call, chainId) : undefined))
   const results = useRawCalls(rawCalls)

--- a/packages/core/src/hooks/useCall.ts
+++ b/packages/core/src/hooks/useCall.ts
@@ -4,7 +4,7 @@ import { ContractMethodNames, Falsy, Params, TypedContract } from '../model/type
 import { useRawCalls } from './useRawCalls'
 import { CallResult, decodeCallResult, encodeCallData } from '../helpers'
 import { QueryParams } from '../constants/type/QueryParams'
-import { useConfig, useNetwork } from '../providers'
+import { useChainId } from './useChainId'
 
 /**
  * @public
@@ -44,9 +44,7 @@ export function useCall<T extends TypedContract, MN extends ContractMethodNames<
  * @returns a list of results (see {@link CallResult} in {@link useCall} above).
  */
 export function useCalls(calls: (Call | Falsy)[], queryParams: QueryParams = {}): CallResult<Contract, string>[] {
-  const { network } = useNetwork()
-  const { readOnlyChainId } = useConfig()
-  const chainId = queryParams.chainId ?? network.chainId ?? readOnlyChainId
+  const chainId = useChainId({queryParams})
 
   const rawCalls = calls.map((call) => (chainId !== undefined ? encodeCallData(call, chainId) : undefined))
   const results = useRawCalls(rawCalls)

--- a/packages/core/src/hooks/useChainId.ts
+++ b/packages/core/src/hooks/useChainId.ts
@@ -1,0 +1,17 @@
+import { QueryParams } from '../constants/type/QueryParams'
+import { useConfig, useNetwork } from '../providers'
+
+export interface UseChainIdOptions {
+  queryParams?: QueryParams
+}
+
+/**
+ * Internal hook for reading current chainId for calls.
+ * @internal
+ */
+export function useChainId(opts: UseChainIdOptions) {
+  const { network } = useNetwork()
+  const { readOnlyChainId } = useConfig()
+  return opts?.queryParams?.chainId ?? network.chainId ?? readOnlyChainId
+
+}

--- a/packages/core/src/hooks/useChainId.ts
+++ b/packages/core/src/hooks/useChainId.ts
@@ -13,5 +13,4 @@ export function useChainId(opts: UseChainIdOptions) {
   const { network } = useNetwork()
   const { readOnlyChainId } = useConfig()
   return opts?.queryParams?.chainId ?? network.chainId ?? readOnlyChainId
-
 }

--- a/packages/core/src/hooks/useChainState.ts
+++ b/packages/core/src/hooks/useChainState.ts
@@ -7,7 +7,7 @@ export function useChainState(
   queryParams: QueryParams = {}
 ): (Partial<SingleChainState> & { dispatchCalls: (action: Action) => void }) | undefined {
   const multiChainState = useContext(MultiChainStatesContext)
-  const chainId = useChainId({queryParams})
+  const chainId = useChainId({ queryParams })
 
   if (chainId === undefined) {
     return undefined

--- a/packages/core/src/hooks/useChainState.ts
+++ b/packages/core/src/hooks/useChainState.ts
@@ -1,14 +1,14 @@
 import { useContext } from 'react'
 import { QueryParams } from '../constants/type/QueryParams'
 import { Action, MultiChainStatesContext, SingleChainState, useNetwork } from '../providers'
+import { useChainId } from './useChainId'
 
 export function useChainState(
   queryParams: QueryParams = {}
 ): (Partial<SingleChainState> & { dispatchCalls: (action: Action) => void }) | undefined {
   const multiChainState = useContext(MultiChainStatesContext)
 
-  const { network } = useNetwork()
-  const chainId = queryParams.chainId ?? network.chainId
+  const chainId = useChainId({queryParams})
 
   if (chainId === undefined) {
     return undefined

--- a/packages/core/src/hooks/useContractCall.ts
+++ b/packages/core/src/hooks/useContractCall.ts
@@ -56,7 +56,7 @@ export function useContractCalls(
   calls: (ContractCall | Falsy)[],
   queryParams: QueryParams = {}
 ): (any[] | undefined)[] {
-  const chainId = useChainId({queryParams})
+  const chainId = useChainId({ queryParams })
 
   const results = useChainCalls(
     calls.map((call) => (chainId !== undefined ? encodeCallData(call, chainId) : undefined))

--- a/packages/core/src/hooks/useContractCall.ts
+++ b/packages/core/src/hooks/useContractCall.ts
@@ -1,10 +1,11 @@
 import { Interface } from '@ethersproject/abi'
 import { useMemo } from 'react'
-import { Falsy } from '../model/types'
-import { useChainCalls } from './useChainCalls'
-import { RawCall, useConfig, useNetwork } from '../providers'
 import { ChainId } from '../constants'
 import { QueryParams } from '../constants/type/QueryParams'
+import { Falsy } from '../model/types'
+import { RawCall } from '../providers'
+import { useChainCalls } from './useChainCalls'
+import { useChainId } from './useChainId'
 
 function warnOnInvalidContractCall(call: ContractCall | Falsy) {
   console.warn(
@@ -55,9 +56,7 @@ export function useContractCalls(
   calls: (ContractCall | Falsy)[],
   queryParams: QueryParams = {}
 ): (any[] | undefined)[] {
-  const { network } = useNetwork()
-  const { readOnlyChainId } = useConfig()
-  const chainId = queryParams.chainId ?? network.chainId ?? readOnlyChainId
+  const chainId = useChainId({queryParams})
 
   const results = useChainCalls(
     calls.map((call) => (chainId !== undefined ? encodeCallData(call, chainId) : undefined))


### PR DESCRIPTION
- Hook only for internal use, not exported