### PR TITLE
👛 Add throw error to activateBrowserWallet

### DIFF
--- a/.changeset/green-keys-juggle.md
+++ b/.changeset/green-keys-juggle.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+Add error throwing to browser wallet activation

--- a/packages/core/src/providers/network/network/provider.tsx
+++ b/packages/core/src/providers/network/network/provider.tsx
@@ -43,7 +43,7 @@ export function NetworkProvider({ children, providerOverride }: NetworkProviderP
     if (!injectedProvider) {
       reportError(new Error('No injected provider available'))
       setLoading(false)
-      return
+      throw new Error('No injected provider available')
     }
     try {
       await injectedProvider.send('eth_requestAccounts', [])


### PR DESCRIPTION
I'm opening up a PR to potentially throw an error during a call to `activateBrowserWallet` if there is no injected provider detected.  This will allow for setting an error like so:

```
const [error, setError] = useState<string | undefined>(undefined)
...

<MyConnectionComponent
  ...rest of props
  onClick={async () => {
      try {
          await activateBrowserWallet();
      } catch (e) {
          // handle if there is a message property, otherwise return raw message string
          setError(e.message ?? e);
      }
  }}
/>
```

This will [match the flow later down in the function](https://github.com/TrueFiEng/useDApp/blob/master/packages/core/src/providers/network/network/provider.tsx#L52-L54) that throws if there is a failure during `eth_requestAccounts`.

I believe this would be an improvement over the current method of tracking an `error` from `useEthers` in that only the most recent error is returned from the `useEthers` hook.  While this is more declarative, it puts the onus on developers to persist this error if it were to change, which is effectively what setting it in a `catch` statement would do.