### PR TITLE
👽 Update usePromiseTransaction.ts error message

### DIFF
--- a/packages/core/src/hooks/usePromiseTransaction.ts
+++ b/packages/core/src/hooks/usePromiseTransaction.ts
@@ -61,7 +61,7 @@ export function usePromiseTransaction(chainId: number | undefined, options?: Tra
         setState({ receipt, transaction, status: 'Success', chainId })
         return receipt
       } catch (e: any) {
-        const errorMessage = e.error?.message ?? e.reason ?? e.data?.message ?? e.message
+        const errorMessage = e.error?.data?.message ?? e.error?.message ?? e.reason ?? e.data?.message ?? e.message
         if (transaction) {
           const droppedAndReplaced = isDroppedAndReplaced(e)
 


### PR DESCRIPTION
### Description

This changes check for `e.error?.data?.message` and help to specify error message when transaction fails.
Currently it returns `Internal JSON-RPC error`.