### PR TITLE
➕ Add stricter contract type check on the useLogs hook

### DIFF
--- a/.changeset/add-sctriter-check-useLogs.md
+++ b/.changeset/add-sctriter-check-useLogs.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+➕ Add stricter contract type check on the useLogs hook

--- a/packages/core/src/hooks/useLogs.ts
+++ b/packages/core/src/hooks/useLogs.ts
@@ -26,7 +26,10 @@ export interface TypedFilter<
  * @returns an array of decoded logs (see {@link LogsResult})
  * @public
  */
-export function useLogs(filter: TypedFilter | Falsy, queryParams: LogQueryParams = {}): LogsResult<Contract, string> {
+export function useLogs<T extends TypedContract = Contract, EN extends ContractEventNames<T> = ContractEventNames<T>>(
+  filter: TypedFilter<T, EN> | Falsy,
+  queryParams: LogQueryParams = {}
+): LogsResult<T, EN> {
   const { fromBlock, toBlock, blockHash } = queryParams
 
   const rawFilter = useMemo(() => encodeFilterData(filter, fromBlock, toBlock, blockHash), [


### PR DESCRIPTION
Using generics in the **TypedFilter** interface add some nice type checks to the filter parameter of _useLogs_, but it doesn't help the user when creating the parameter, unless they go out of their way to instantiate he object with the _TypedFilter_ type specified. This way, the check is provided directly by the function. It can still be bypassed, if one wishes to, by calling it this way: 
```typescript
useLogs<Contract>(...)
```

I feel like this change could be applied to most hooks.

As a sidenote, I tried to make the output's value.data property typed, but I couldn't.
The best I could do was this, but it would work only if you could import *TypedEventFilter* from typechain's common file.
Maybe someone more skilled can work this out.
```typescript
type EventReturnTemp<T extends TypedContract, EN extends ContractEventNames<T>> = ReturnType<
  T['filters'][EN]
> extends TypedEventFilter<infer X> // This is the issue: you need TypedEventFilter
  ? Omit<{ [K in keyof X['args'] as K extends `${number}` ? never : K]: X['args'][K] } , keyof Array<any>> : never"
```
