### PR TITLE
🐸 Added error hash returned to transaction status

### DIFF
--- a/.changeset/hash-transaction-status.md
+++ b/.changeset/hash-transaction-status.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+Added error hash returned to transaction status

--- a/packages/core/src/hooks/usePromiseTransaction.ts
+++ b/packages/core/src/hooks/usePromiseTransaction.ts
@@ -81,6 +81,7 @@ export function usePromiseTransaction(chainId: number | undefined, options?: Tra
       } catch (e: any) {
         const parsedErrorCode = parseInt(e.error?.data?.code ?? e.error?.code ?? e.data?.code ?? e.code)
         const errorCode = isNaN(parsedErrorCode) ? undefined : parsedErrorCode
+        const errorHash = parseInt(e.error?.data?.data ?? e.error?.data ?? e.data?.data ?? e.data)
         const errorMessage = e.error?.data?.message ?? e.error?.message ?? e.reason ?? e.data?.message ?? e.message
         if (transaction) {
           const droppedAndReplaced = isDroppedAndReplaced(e)
@@ -108,13 +109,14 @@ export function usePromiseTransaction(chainId: number | undefined, options?: Tra
               receipt: e.receipt,
               errorMessage,
               errorCode,
+              errorHash,
               chainId,
             })
           } else {
-            setState({ status: 'Fail', transaction, receipt: e.receipt, errorMessage, errorCode, chainId })
+            setState({ status: 'Fail', transaction, receipt: e.receipt, errorMessage, errorCode, errorHash, chainId })
           }
         } else {
-          setState({ status: 'Exception', errorMessage, errorCode, chainId })
+          setState({ status: 'Exception', errorMessage, errorCode, errorHash, chainId })
         }
         return undefined
       }

--- a/packages/core/src/hooks/usePromiseTransaction.ts
+++ b/packages/core/src/hooks/usePromiseTransaction.ts
@@ -81,7 +81,7 @@ export function usePromiseTransaction(chainId: number | undefined, options?: Tra
       } catch (e: any) {
         const parsedErrorCode = parseInt(e.error?.data?.code ?? e.error?.code ?? e.data?.code ?? e.code)
         const errorCode = isNaN(parsedErrorCode) ? undefined : parsedErrorCode
-        const errorHash = e.error?.data?.data ?? e.error?.data ?? e.data?.data ?? e.data
+        const errorHash = e?.error?.data?.originalError?.data ?? e?.error?.data;
         const errorMessage = e.error?.data?.message ?? e.error?.message ?? e.reason ?? e.data?.message ?? e.message
         if (transaction) {
           const droppedAndReplaced = isDroppedAndReplaced(e)

--- a/packages/core/src/hooks/usePromiseTransaction.ts
+++ b/packages/core/src/hooks/usePromiseTransaction.ts
@@ -81,7 +81,7 @@ export function usePromiseTransaction(chainId: number | undefined, options?: Tra
       } catch (e: any) {
         const parsedErrorCode = parseInt(e.error?.data?.code ?? e.error?.code ?? e.data?.code ?? e.code)
         const errorCode = isNaN(parsedErrorCode) ? undefined : parsedErrorCode
-        const errorHash = parseInt(e.error?.data?.data ?? e.error?.data ?? e.data?.data ?? e.data)
+        const errorHash = e.error?.data?.data ?? e.error?.data ?? e.data?.data ?? e.data
         const errorMessage = e.error?.data?.message ?? e.error?.message ?? e.reason ?? e.data?.message ?? e.message
         if (transaction) {
           const droppedAndReplaced = isDroppedAndReplaced(e)

--- a/packages/core/src/hooks/usePromiseTransaction.ts
+++ b/packages/core/src/hooks/usePromiseTransaction.ts
@@ -81,7 +81,7 @@ export function usePromiseTransaction(chainId: number | undefined, options?: Tra
       } catch (e: any) {
         const parsedErrorCode = parseInt(e.error?.data?.code ?? e.error?.code ?? e.data?.code ?? e.code)
         const errorCode = isNaN(parsedErrorCode) ? undefined : parsedErrorCode
-        const errorHash = e?.error?.data?.originalError?.data ?? e?.error?.data;
+        const errorHash = e?.error?.data?.originalError?.data ?? e?.error?.data
         const errorMessage = e.error?.data?.message ?? e.error?.message ?? e.reason ?? e.data?.message ?? e.message
         if (transaction) {
           const droppedAndReplaced = isDroppedAndReplaced(e)

--- a/packages/core/src/model/TransactionStatus.ts
+++ b/packages/core/src/model/TransactionStatus.ts
@@ -15,6 +15,7 @@ export interface TransactionStatus {
   chainId?: number
   errorMessage?: string
   errorCode?: number
+  errorHash?: string
   originalTransaction?: TransactionResponse
 }
 


### PR DESCRIPTION
we can decode this hash and can be used to show error messages. This will be used mostly in custom error messages.