### PR TITLE
⛽ Fix gas limit override in useContractFunction hook

### DIFF
--- a/packages/core/src/hooks/useContractFunction.ts
+++ b/packages/core/src/hooks/useContractFunction.ts
@@ -99,8 +99,8 @@ export function useContractFunction<T extends TypedContract, FN extends Contract
         )
 
         const modifiedOpts = {
-          ...opts,
           gasLimit,
+          ...opts,
         }
         const modifiedArgs = hasOpts ? args.slice(0, args.length - 1) : args
         modifiedArgs.push(modifiedOpts)


### PR DESCRIPTION
**Description**

This fix adds opportunity to override gasLimit property when passing it to `send` method of useContractFunction hook.

It can be useful for troubleshooting and debugging failed transactions. Passing gasLimit helps to push transaction to the wallet even if transaction is going to fail.