### PR TITLE
🌄 Fix field in website example code

### DIFF
--- a/packages/website/src/index.html
+++ b/packages/website/src/index.html
@@ -289,7 +289,7 @@
                 <pre
                   class="window-pre"
                 ><code class="code" data-lines="1"><span class="code--red">const</span> config: Config = {
-    readOnlyChain: ChainId.Mainnet,
+    readOnlyChainId: ChainId.Mainnet,
     readOnlyUrls: {
       [ChainId.Mainnet]: 'https://mainnet.infura.io/v3/62687d1a985d4508b2b7a24827551934',
     },


### PR DESCRIPTION
The example code at [https://usedapp.io/#example](https://usedapp.io/#example) causes a type error due to a mis-named field. This PR fixes that. 

Note: The `readOnlyChain` field was renamed to `readOnlyChainId` as part of 8b8fb819b1cf7f71109ac025c52a1ed07df67569.

Related:

https://github.com/TrueFiEng/useDApp/blob/dfa48f552320cb771d7812e1d694960d4b581b69/packages/core/src/model/Config.ts#L12

https://github.com/TrueFiEng/useDApp/blob/8b8fb819b1cf7f71109ac025c52a1ed07df67569/packages/core/src/model/config/Config.ts#L12

![image](https://user-images.githubusercontent.com/2955510/184436285-3a9da2ee-9639-497f-abf0-f0883a62c899.png)
![image](https://user-images.githubusercontent.com/2955510/184436098-b7f8cdc9-1a61-40dd-a36a-ef7e49477fc0.png)
![image](https://user-images.githubusercontent.com/2955510/184436138-f1d8411d-082a-4596-bb47-d6017fc83a15.png)
![image](https://user-images.githubusercontent.com/2955510/184436206-9fe7aa42-8e87-4eb1-9fbc-ac1febb64937.png)
