### PR TITLE
🪡 Fix example hook

### DIFF
--- a/packages/website/src/index.html
+++ b/packages/website/src/index.html
@@ -328,22 +328,31 @@
               <div class="window">
                 <pre
                   class="window-pre"
-                ><code class="code" data-lines="1"><span class="code--blue">function</span> useTokenBalance (
+                ><code class="code" data-lines="1"><span class="code--blue">function</span> useTokenBalance(
   tokenAddress: string | Falsy,
   address: string | Falsy
-) {
-  <span class="code--red">const</span> [tokenBalance] =
-    useContractCall (
+): BigNumber | undefined {
+
+  <span class="code--red">const</span> { value, error } =
+    useCall(
       address && tokenAddress && {
-          abi: ERC20Interface,<span class="code--gray"> // ABI interface of the called contract</span>
-          address: tokenAddress,<span class="code--gray"> // On-chain address of the deployed contract</span>
+          contract: new Contract(tokenAddress, ERC20Interface),<span class="code--gray"> // Contract instance</span>
           method: "balanceOf",<span class="code--gray"> // Method to be called</span>
           args: [address],<span class="code--gray"> // Method arguments - address to be checked for balance</span>
         }
-    ) ?? [ ];
- <span class="code--red">return</span> tokenBalance;
+    ) ?? { };
+
+  if(error) {
+    console.error(error.message)
+    <span class="code--red">return</span> undefined
+  }
+
+  <span class="code--red">const</span> { tokenBalance } = value || { }
+
+  <span class="code--red">return</span> tokenBalance;
+
 }
-  <span class="code__lines">1<br>2<br>3<br>4<br>5<br>6<br>7<br>8<br>9<br>10<br>11<br>12<br>13<br>14<br>15</span></code></pre>
+                  <span class="code__lines">1<br>2<br>3<br>4<br>5<br>6<br>7<br>8<br>9<br>10<br>11<br>12<br>13<br>14<br>15</span></code></pre>
               </div>
 
               <div data-animations="animate__slideInRight" class="slider__btns animate__animated animate__slideInRight">

--- a/packages/website/src/index.html
+++ b/packages/website/src/index.html
@@ -14,12 +14,12 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://usedapp.io/" />
     <meta property="og:title" content="useDApp | Ethereum and React cooperating" />
-    <meta 
-      property="og:description" 
-      content="useDApp is framework for rapid Dapp development. Simple. Robust. Extendable. Testable." 
+    <meta
+      property="og:description"
+      content="useDApp is framework for rapid Dapp development. Simple. Robust. Extendable. Testable."
       />
-    <meta 
-      property="og:image" 
+    <meta
+      property="og:image"
       content="https://usedapp.io/img/welcome.png"
 
     />
@@ -27,12 +27,12 @@
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:url" content="https://usedapp.io/" />
     <meta property="twitter:title" content="useDApp | Ethereum and React cooperating" />
-    <meta 
-      property="twitter:description" 
-      content="useDApp is framework for rapid Dapp development. Simple. Robust. Extendable. Testable." 
+    <meta
+      property="twitter:description"
+      content="useDApp is framework for rapid Dapp development. Simple. Robust. Extendable. Testable."
     />
-    <meta 
-      property="twitter:image" 
+    <meta
+      property="twitter:image"
       content="https://usedapp.io/img/welcome.png"
     />
 
@@ -294,7 +294,7 @@
       [ChainId.Mainnet]: 'https://mainnet.infura.io/v3/62687d1a985d4508b2b7a24827551934',
     },
   }
-    
+
   ReactDOM.render (
     &lt;React.StrictMode&gt;
       &lt;DAppProvider config={config}&gt;
@@ -315,7 +315,7 @@
 <span class="code--red">export </span><span class="code--blue">function</span> TokenBalance( ) {
     const { account } = useEthers( )
     const tokenBalance = useTokenBalance(DAI, account)
-                  
+
 <span class="code--red">return</span> (
       &lt;div&gt;
          {tokenBalance && &lt;p&gt;Balance: {formatUnits(tokenBalance, 18)}&lt;/p&gt;}
@@ -336,9 +336,9 @@
     useContractCall (
       address && tokenAddress && {
           abi: ERC20Interface,<span class="code--gray"> // ABI interface of the called contract</span>
-          address: tokenAddress,<span class="code--gray"> // On-chain address of the deployed contract</span> 
-          method: "balanceOf",<span class="code--gray"> // Method to be called</span> 
-          args: [address],<span class="code--gray"> // Method arguments - address to be checked for balance</span> 
+          address: tokenAddress,<span class="code--gray"> // On-chain address of the deployed contract</span>
+          method: "balanceOf",<span class="code--gray"> // Method to be called</span>
+          args: [address],<span class="code--gray"> // Method arguments - address to be checked for balance</span>
         }
     ) ?? [ ];
  <span class="code--red">return</span> tokenBalance;

--- a/packages/website/src/index.html
+++ b/packages/website/src/index.html
@@ -333,7 +333,7 @@
   address: string | Falsy
 ): BigNumber | undefined {
 
-  <span class="code--red">const</span> { value, error } =
+  <span class="code--red">const</span> { value } =
     useCall(
       address && tokenAddress && {
           contract: new Contract(tokenAddress, ERC20Interface),<span class="code--gray"> // Contract instance</span>
@@ -342,13 +342,8 @@
         }
     ) ?? { };
 
-  if (error) {
-    console.error(error.message)
-    <span class="code--red">return</span> undefined
-  }
-
-  <span class="code--red">const</span> value?.[0]
-
+  <span class="code--red">const</span> [tokenBalance] = value ?? []
+  <span class="code--red">return</span> tokenBalance
 }
                   <span class="code__lines">1<br>2<br>3<br>4<br>5<br>6<br>7<br>8<br>9<br>10<br>11<br>12<br>13<br>14<br>15</span></code></pre>
               </div>

--- a/packages/website/src/index.html
+++ b/packages/website/src/index.html
@@ -342,14 +342,12 @@
         }
     ) ?? { };
 
-  if(error) {
+  if (error) {
     console.error(error.message)
     <span class="code--red">return</span> undefined
   }
 
-  <span class="code--red">const</span> { tokenBalance } = value || { }
-
-  <span class="code--red">return</span> tokenBalance;
+  <span class="code--red">const</span> value?.[0]
 
 }
                   <span class="code__lines">1<br>2<br>3<br>4<br>5<br>6<br>7<br>8<br>9<br>10<br>11<br>12<br>13<br>14<br>15</span></code></pre>


### PR DESCRIPTION
The `useTokenBalance()` hook in the website's example code references a deprecated hook, `useContractCall()`:

```ts
function useTokenBalance(
	tokenAddress: string|Falsy,
	address: string|Falsy): BigNumber|undefined
{
	const [tokenBalance] = useContractCall (
		address && tokenAddress && {
			abi: ERC20Interface, // ABI interface of the called contract
			address: tokenAddress, // On-chain address of the deployed contract
			method: "balanceOf", // Method to be called
			args: [address], // Method arguments - address to be checked for balance
			}
		) ?? [ ];

	return tokenBalance;

}
```

https://github.com/TrueFiEng/useDApp/blob/master/packages/website/src/index.html#L336

This call yields a deprecation warning in editors like VS Code:

![image](https://user-images.githubusercontent.com/2955510/184682157-210846a0-3b63-4f01-9891-05ae6d9017fb.png)

This PR updates the `useTokenBalance()` implementation to instead call `useCall()`, following the hook's `@example` code as closely as possible:

```ts
function useTokenBalance(
	tokenAddress: string|Falsy,
	address: string|Falsy): BigNumber|undefined
{
	const { value, error } = useCall(
		address && tokenAddress && {
			contract: new Contract(tokenAddress, ERC20Interface), // Contract instance
			method: "balanceOf", // Method to be called
			args: [address], // Method arguments - address to be checked for balance
			}
		) ?? {};

	if(error) {
		console.error(error.message)
		return undefined
	}

	const { balance } = value || {}

	return balance

}
```
Screenshot of the updated page example running on localhost:

![image](https://user-images.githubusercontent.com/2955510/184681983-af6b8580-3ccc-4aa0-9712-09f69e59dfd2.png)