### PR TITLE
🦤 Add rpcUrl to xdai

### DIFF
--- a/.changeset/big-chairs-yell.md
+++ b/.changeset/big-chairs-yell.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+fix: add `rpcUrl` to xdai

--- a/packages/core/src/model/chain/xdai.ts
+++ b/packages/core/src/model/chain/xdai.ts
@@ -5,6 +5,7 @@ export const xDai: Chain = {
   chainName: 'xDai',
   isTestChain: false,
   isLocalChain: false,
+  rpcUrl: 'https://rpc.gnosischain.com/',
   multicallAddress: '0xb5b692a88bdfc81ca69dcb1d924f59f0413a602a',
   getExplorerAddressLink: (address: string) => `https://blockscout.com/poa/xdai/address/${address}/transactions`,
   getExplorerTransactionLink: (transactionHash: string) =>


### PR DESCRIPTION
Add rpcUrl to gnosis chain  (former xdai) and close #934 
This enables the feature "add network" when gnosis chain in metamask isn't found.