### PR TITLE
🐶 Change BNB decimals on BSC from 8 to 18

### DIFF
--- a/.changeset/unlucky-countries-notice.md
+++ b/.changeset/unlucky-countries-notice.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+fix: change BNB decimals on BSC from 8 to 18

--- a/packages/core/src/model/chain/bsc.ts
+++ b/packages/core/src/model/chain/bsc.ts
@@ -11,7 +11,7 @@ export const BSC: Chain = {
   nativeCurrency: {
     name: 'BNB',
     symbol: 'BNB',
-    decimals: 8,
+    decimals: 18,
   },
   getExplorerAddressLink: (address: string) => `https://bscscan.com/address/${address}`,
   getExplorerTransactionLink: (transactionHash: string) => `https://bscscan.com/tx/${transactionHash}`,


### PR DESCRIPTION
on BSC, the native token decimals is 18, while the decimals on BC is 8.