### PR TITLE
🪟 Simplify window provider

### DIFF
--- a/.changeset/brave-planes-teach.md
+++ b/.changeset/brave-planes-teach.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+🪟 Return boolean instead of object in window provider

--- a/packages/core/src/hooks/useBlockNumber.ts
+++ b/packages/core/src/hooks/useBlockNumber.ts
@@ -16,7 +16,7 @@ export function useBlockNumber(): number | undefined {
   const readOnlyNetworks = useReadonlyNetworks()
   const { connector } = useConnector()
   const [blockNumber, setBlockNumber] = useState<number>()
-  const { isActive } = useWindow()
+  const isActive = useWindow()
   const isMounted = useIsMounted()
 
   useEffect(() => {

--- a/packages/core/src/providers/blockNumber/blockNumbers/provider.tsx
+++ b/packages/core/src/providers/blockNumber/blockNumbers/provider.tsx
@@ -14,7 +14,7 @@ interface Props {
 export function BlockNumbersProvider({ children }: Props) {
   const networks = useReadonlyNetworks()
   const [state, dispatch] = useReducer(blockNumberReducer, {})
-  const { isActive } = useWindow()
+  const isActive = useWindow()
   const isMounted = useIsMounted()
 
   useEffect(() => {

--- a/packages/core/src/providers/chainState/multiChainStates/provider.tsx
+++ b/packages/core/src/providers/chainState/multiChainStates/provider.tsx
@@ -44,7 +44,7 @@ export function MultiChainStateProvider({ children, multicallAddresses }: Props)
   const networks = useReadonlyNetworks()
   const blockNumbers = useBlockNumbers()
   const dispatchNetworksState = useUpdateNetworksState()
-  const { isActive } = useWindow()
+  const isActive = useWindow()
 
   const [calls, dispatchCalls] = useReducer(callsReducer, [])
   const [state, dispatchState] = useReducer(chainStateReducer, {})

--- a/packages/core/src/providers/network/readonlyNetworks/provider.tsx
+++ b/packages/core/src/providers/network/readonlyNetworks/provider.tsx
@@ -37,7 +37,7 @@ export const getProvidersFromConfig = (readOnlyUrls: NodeUrls) =>
 
 export function ReadonlyNetworksProvider({ providerOverrides = {}, children }: NetworkProviderProps) {
   const { readOnlyUrls = {}, pollingInterval, pollingIntervals } = useConfig()
-  const { isActive } = useWindow()
+  const isActive = useWindow()
   const [providers, setProviders] = useState<Providers>(() => ({
     ...getProvidersFromConfig(readOnlyUrls),
     ...providerOverrides,

--- a/packages/core/src/providers/window/context.ts
+++ b/packages/core/src/providers/window/context.ts
@@ -3,11 +3,7 @@ import { createContext, useContext } from 'react'
 /**
  * @internal Intended for internal use - use it on your own risk
  */
-export const WindowContext = createContext<{
-  isActive: boolean
-}>({
-  isActive: true,
-})
+export const WindowContext = createContext<boolean>(true)
 
 /**
  * @internal

--- a/packages/core/src/providers/window/provider.tsx
+++ b/packages/core/src/providers/window/provider.tsx
@@ -26,5 +26,5 @@ export function WindowProvider({ children }: Props) {
     return () => document.removeEventListener('visibilitychange', visibilityChangeListener)
   }, [])
 
-  return <WindowContext.Provider value={{ isActive: isActiveWindow }} children={children} />
+  return <WindowContext.Provider value={isActiveWindow} children={children} />
 }


### PR DESCRIPTION
Creating new object on every state change is probably not necessary here and just simple boolean can be returned.