### PR TITLE
⛽ Avoid calling estimateGas in useContractFunction when gasLimit is passed explicitly

### DIFF
--- a/.changeset/spotty-cows-exist.md
+++ b/.changeset/spotty-cows-exist.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+⛽ Avoid calling estimateGas in useContractFunction when gasLimit is passed explicitly

--- a/packages/core/src/hooks/useContractFunction.ts
+++ b/packages/core/src/hooks/useContractFunction.ts
@@ -96,8 +96,14 @@ export function useContractFunction<T extends TypedContract, FN extends Contract
         const opts = hasOpts ? args[args.length - 1] : undefined
 
         const gasLimit =
-          (await estimateContractFunctionGasLimit(contractWithSigner, functionName, args, gasLimitBufferPercentage)) ??
-          BigNumber.from(0)
+          typeof opts === 'object' && Object.prototype.hasOwnProperty.call(opts, 'gasLimit')
+            ? opts.gasLimit
+            : (await estimateContractFunctionGasLimit(
+                contractWithSigner,
+                functionName,
+                args,
+                gasLimitBufferPercentage
+              )) ?? BigNumber.from(0)
 
         const modifiedOpts = {
           gasLimit,


### PR DESCRIPTION
hi folks, thanks for your efforts being put into the framework, I enjoy using it for more than a year already. 🤝 

I noticed that in some of recent releases you've introduced  [gasLimitBufferPercentage](https://github.com/TrueFiEng/useDApp/pull/746) feature which is fine, but I just decided to push a small patch if it makes sense to you.

currently, on each `send` of `useContractFunction`  `estimateGas` is being called to modify transaction overrides with custom `gasLimit`. however, if `gasLimit` is passed explicitly in transaction overrides object, the value received by `estimateContractFunctionGasLimit` is being overwritten by it, and it appears that there was no point in calling `estimateContractFunctionGasLimit`.

this adds a check to skip calling `estimateContractFunctionGasLimit` if `gasLimit` is passed explicitly