### PR TITLE
🥐 Keep transactionName in notifications after the transaction is mined

### DIFF
--- a/.changeset/polite-ants-double.md
+++ b/.changeset/polite-ants-double.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+Keep transactionName in notifications after the transaction is mined

--- a/packages/core/src/hooks/usePromiseTransaction.ts
+++ b/packages/core/src/hooks/usePromiseTransaction.ts
@@ -166,6 +166,7 @@ export function usePromiseTransaction(chainId: number | undefined, options?: Tra
         chainId: chainId,
       },
       receipt,
+      transactionName: options?.transactionName,
     })
     setState({ receipt, transaction, status: 'Success', chainId })
     return { transaction, receipt }


### PR DESCRIPTION
Closes https://github.com/TrueFiEng/useDApp/issues/1022