### PR TITLE
🧤 Add non-empty data string in Send Transaction

### DIFF
--- a/.changeset/tame-knives-sneeze.md
+++ b/.changeset/tame-knives-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+🧤 Add non-empty data string in Send Transaction for restoring Gnosis Safe integration

--- a/packages/core/src/helpers/gnosisSafeUtils.ts
+++ b/packages/core/src/helpers/gnosisSafeUtils.ts
@@ -68,7 +68,7 @@ const EIP712_SAFE_TX_TYPE = {
 export const sanitizeTransactionRequest = (transactionRequest: TransactionRequest): TransactionRequest => {
   return {
     ...transactionRequest,
-    data: transactionRequest.data ?? '0x' // Non-empty data string is required on Gnosis Safe side.
+    data: transactionRequest.data ?? '0x', // Non-empty data string is required on Gnosis Safe side.
   }
 }
 

--- a/packages/core/src/helpers/gnosisSafeUtils.ts
+++ b/packages/core/src/helpers/gnosisSafeUtils.ts
@@ -1,4 +1,4 @@
-import { TransactionResponse, TransactionReceipt } from '@ethersproject/abstract-provider'
+import { TransactionResponse, TransactionReceipt, TransactionRequest } from '@ethersproject/abstract-provider'
 import { BigNumber, BigNumberish, Contract, Event } from 'ethers'
 import { utils, constants } from 'ethers'
 import { getChainById } from './chain'
@@ -63,6 +63,13 @@ const EIP712_SAFE_TX_TYPE = {
     { type: 'address', name: 'refundReceiver' },
     { type: 'uint256', name: 'nonce' },
   ],
+}
+
+export const sanitizeTransactionRequest = (transactionRequest: TransactionRequest): TransactionRequest => {
+  return {
+    ...transactionRequest,
+    data: transactionRequest.data ?? '0x' // Non-empty data string is required on Gnosis Safe side.
+  }
 }
 
 export const calculateSafeTransactionHash = (

--- a/packages/core/src/hooks/useSendTransaction.ts
+++ b/packages/core/src/hooks/useSendTransaction.ts
@@ -7,6 +7,7 @@ import { useReadonlyNetworks } from '../providers/network/readonlyNetworks/conte
 import { ChainId } from '../constants'
 import { getSignerFromOptions } from '../helpers/getSignerFromOptions'
 import { providers } from 'ethers'
+import { sanitizeTransactionRequest } from '../helpers/gnosisSafeUtils'
 
 /**
  * Hook returns an object with three variables: `state`, `resetState`, and `sendTransaction`.

--- a/packages/core/src/hooks/useSendTransaction.ts
+++ b/packages/core/src/hooks/useSendTransaction.ts
@@ -49,10 +49,10 @@ export function useSendTransaction(options?: TransactionOptions) {
       const gasLimit = await estimateTransactionGasLimit(transactionRequest, signer, gasLimitBufferPercentage)
 
       return promiseTransaction(
-        signer.sendTransaction({
+        signer.sendTransaction(sanitizeTransactionRequest({
           ...transactionRequest,
           gasLimit,
-        }),
+        })),
         {
           safeTransaction: {
             to: transactionRequest.to,

--- a/packages/core/src/hooks/useSendTransaction.ts
+++ b/packages/core/src/hooks/useSendTransaction.ts
@@ -49,10 +49,12 @@ export function useSendTransaction(options?: TransactionOptions) {
       const gasLimit = await estimateTransactionGasLimit(transactionRequest, signer, gasLimitBufferPercentage)
 
       return promiseTransaction(
-        signer.sendTransaction(sanitizeTransactionRequest({
-          ...transactionRequest,
-          gasLimit,
-        })),
+        signer.sendTransaction(
+          sanitizeTransactionRequest({
+            ...transactionRequest,
+            gasLimit,
+          })
+        ),
         {
           safeTransaction: {
             to: transactionRequest.to,


### PR DESCRIPTION
This format of non-empty data string is required on Gnosis Safe side.