### PR TITLE
🍆 Update optimism goerli etherscan link

### DIFF
--- a/.changeset/tricky-spiders-cheer.md
+++ b/.changeset/tricky-spiders-cheer.md
@@ -1,0 +1,5 @@
+---
+'@usedapp/core': patch
+---
+
+Update optimism goerli etherscan link

--- a/packages/core/src/model/chain/optimism.ts
+++ b/packages/core/src/model/chain/optimism.ts
@@ -20,7 +20,7 @@ export const OptimismKovan: Chain = {
   getExplorerTransactionLink: getTransactionLink(testnetExplorerUrl),
 }
 
-const testnetGoerliExplorerUrl = 'https://goerli-optimism.etherscan.io/'
+const testnetGoerliExplorerUrl = 'https://goerli-optimism.etherscan.io'
 
 export const OptimismGoerli: Chain = {
   chainId: 420,


### PR DESCRIPTION
There's a double slash when calling `network.getExplorerTransactionLink(txHash)`
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/55240109/207023862-714d24f5-c3d4-446d-99f3-8d23c4ecdb0d.png">
