### PR TITLE
⛽ Fix default gasLimit when estimateContractFunctionGasLimit throw error

### DIFF
--- a/.changeset/fluffy-houses-roll.md
+++ b/.changeset/fluffy-houses-roll.md
@@ -1,0 +1,5 @@
+---
+'@usedapp/core': patch
+---
+
+Set default gasLimit to null instead of 0

--- a/packages/core/src/hooks/useContractFunction.ts
+++ b/packages/core/src/hooks/useContractFunction.ts
@@ -1,6 +1,6 @@
 import { TransactionOptions } from '../model/TransactionOptions'
 import { useConfig } from './useConfig'
-import { Contract, Signer, providers, BigNumber } from 'ethers'
+import { Contract, Signer, providers } from 'ethers'
 import { useCallback, useState } from 'react'
 import { useEthers } from './useEthers'
 import { estimateContractFunctionGasLimit, usePromiseTransaction } from './usePromiseTransaction'
@@ -103,7 +103,7 @@ export function useContractFunction<T extends TypedContract, FN extends Contract
                 functionName,
                 args,
                 gasLimitBufferPercentage
-              )) ?? BigNumber.from(0)
+              )) ?? null
 
         const modifiedOpts = {
           gasLimit,


### PR DESCRIPTION
 when estimateContractFunctionGasLimit throws an error,  the gasLimit should be null and the ethers contract will be checked again.