### PR TITLE
🛠️ Fix localStorage exceeded the quota error

### DIFF
--- a/.changeset/hip-pumpkins-play.md
+++ b/.changeset/hip-pumpkins-play.md
@@ -1,0 +1,5 @@
+---
+'@usedapp/core': patch
+---
+
+Fix writing to local storage crashing application

--- a/packages/core/src/hooks/useLocalStorage.ts
+++ b/packages/core/src/hooks/useLocalStorage.ts
@@ -18,8 +18,13 @@ function setItem(key: string, value: any, storage: WindowLocalStorage['localStor
     storage.removeItem(key)
   } else {
     const toStore = JSON.stringify(value)
-    storage.setItem(key, toStore)
-    return JSON.parse(toStore)
+    try {
+      storage.setItem(key, toStore)
+      return JSON.parse(toStore)
+    } catch (err) {
+      console.error('Error in localStorage', err)
+      storage.removeItem(key)
+    }
   }
 }
 


### PR DESCRIPTION
1. Added `try catch` to prevent app crash because of `localStorage exceeded the quota` error. 
2. Added item remove from the local storage in `catch` to avoid `localStorage exceeded the quota` error on next setting.

The case when this error can occur:
- setting `transactions` to local storage, when transactions history exceeds storage limit.