### PR TITLE
➕ Add Rave Names resolution

### DIFF
--- a/.changeset/odd-weeks-dance.md
+++ b/.changeset/odd-weeks-dance.md
@@ -1,0 +1,5 @@
+---
+'@usedapp/core': major
+---
+
+Add Rave Names resolution to the useAddressLookup hook, but only if opted-into by the user.

--- a/packages/core/src/hooks/useLookupAddress.ts
+++ b/packages/core/src/hooks/useLookupAddress.ts
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react'
 import { useEthers } from './useEthers'
+import { Contract } from 'ethers'
 
 /**
- * `useLookupAddress` is a hook that is used to retrieve the ENS (e.g. `name.eth`) for a specific address.
+ * `useLookupAddress` is a hook that is used to retrieve the ENS (e.g. `name.eth`) or Rave Names (e.g. `name.ftm`) for a specific address.
  * @param address address to lookup 
+ * @param rave should resolve to Rave Names instead of ENS
  * @returns {} Object with the following:
-  - `ens: string | null | undefined` - ENS name of the account or null if not found.
+  - `ens: string | null | undefined` - ENS or Rave name of the account or null if not found.
   - `isLoading: boolean` - indicates whether the lookup is in progress.
   - `error: Error | null` - error that occurred during the lookup or null if no error occurred.
  * @public
@@ -17,11 +19,12 @@ import { useEthers } from './useEthers'
  *   <p>Account: {ens ?? account}</p>
  * )
  */
-export function useLookupAddress(address: string | undefined) {
+export function useLookupAddress(address: string | undefined, rave: boolean = false) {
   const { library } = useEthers()
   const [ens, setENS] = useState<string | null>()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
+  const rave = new Contract('0x14Ffd1Fa75491595c6FD22De8218738525892101', [{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"internalType":"uint256","name":"index","type":"uint256"}],"name":"getName","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"}], provider);
 
   useEffect(() => {
     let mounted = true
@@ -29,10 +32,17 @@ export function useLookupAddress(address: string | undefined) {
     void (async () => {
       if (!library || !address) return
       try {
-        setIsLoading(true)
-        const resolved = await library.lookupAddress(address)
-        if (!mounted) return
-        setENS(resolved)
+	setIsLoading(true)
+	if (rave) {
+	  // this call will fail anyway if the chain isn't Fantom, so we don't need an extra chainId check
+	  const resolved = await rave.getName(address, 0)
+          if (!mounted) return
+          setENS(resolved)
+	} else {
+	  const resolved = await library.lookupAddress(address)
+          if (!mounted) return
+          setENS(resolved)
+	}
       } catch (e: any) {
         if (!mounted) return
         setError(e)

--- a/packages/core/src/hooks/useLookupAddress.ts
+++ b/packages/core/src/hooks/useLookupAddress.ts
@@ -2,10 +2,14 @@ import { useEffect, useState } from 'react'
 import { useEthers } from './useEthers'
 import { Contract } from 'ethers'
 
+interface LookupAddressOptions {
+  rave?: boolean
+}
+
 /**
  * `useLookupAddress` is a hook that is used to retrieve the ENS (e.g. `name.eth`) or Rave Names (e.g. `name.ftm`) for a specific address.
  * @param address address to lookup 
- * @param rave should resolve to Rave Names instead of ENS
+ * @param options additional options
  * @returns {} Object with the following:
   - `ens: string | null | undefined` - ENS or Rave name of the account or null if not found.
   - `isLoading: boolean` - indicates whether the lookup is in progress.
@@ -19,30 +23,45 @@ import { Contract } from 'ethers'
  *   <p>Account: {ens ?? account}</p>
  * )
  */
-export function useLookupAddress(address: string | undefined, rave: boolean = false) {
+export function useLookupAddress(address: string | undefined, { rave }: LookupAddressOptions = {}) {
   const { library } = useEthers()
   const [ens, setENS] = useState<string | null>()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
-  
+
   useEffect(() => {
     let mounted = true
 
     void (async () => {
       if (!library || !address) return
       try {
-	setIsLoading(true)
-	if (rave) {
-	  const raveContract = new Contract('0x14Ffd1Fa75491595c6FD22De8218738525892101', [{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"internalType":"uint256","name":"index","type":"uint256"}],"name":"getName","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"}], provider);
-	  // this call will fail anyway if the chain isn't Fantom, so we don't need an extra chainId check
-	  const resolved = await raveContract.getName(address, 0)
+        setIsLoading(true)
+        if (rave) {
+          const raveContract = new Contract(
+            '0x14Ffd1Fa75491595c6FD22De8218738525892101',
+            [
+              {
+                inputs: [
+                  { internalType: 'address', name: 'owner', type: 'address' },
+                  { internalType: 'uint256', name: 'index', type: 'uint256' },
+                ],
+                name: 'getName',
+                outputs: [{ internalType: 'string', name: '', type: 'string' }],
+                stateMutability: 'view',
+                type: 'function',
+              },
+            ],
+            library
+          )
+          // this call will fail anyway if the chain isn't Fantom, so we don't need an extra chainId check
+          const resolved = await raveContract.getName(address, 0)
           if (!mounted) return
           setENS(resolved)
-	} else {
-	  const resolved = await library.lookupAddress(address)
+        } else {
+          const resolved = await library.lookupAddress(address)
           if (!mounted) return
           setENS(resolved)
-	}
+        }
       } catch (e: any) {
         if (!mounted) return
         setError(e)

--- a/packages/core/src/hooks/useLookupAddress.ts
+++ b/packages/core/src/hooks/useLookupAddress.ts
@@ -24,8 +24,7 @@ export function useLookupAddress(address: string | undefined, rave: boolean = fa
   const [ens, setENS] = useState<string | null>()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
-  const rave = new Contract('0x14Ffd1Fa75491595c6FD22De8218738525892101', [{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"internalType":"uint256","name":"index","type":"uint256"}],"name":"getName","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"}], provider);
-
+  
   useEffect(() => {
     let mounted = true
 
@@ -34,8 +33,9 @@ export function useLookupAddress(address: string | undefined, rave: boolean = fa
       try {
 	setIsLoading(true)
 	if (rave) {
+	  const raveContract = new Contract('0x14Ffd1Fa75491595c6FD22De8218738525892101', [{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"internalType":"uint256","name":"index","type":"uint256"}],"name":"getName","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"}], provider);
 	  // this call will fail anyway if the chain isn't Fantom, so we don't need an extra chainId check
-	  const resolved = await rave.getName(address, 0)
+	  const resolved = await raveContract.getName(address, 0)
           if (!mounted) return
           setENS(resolved)
 	} else {


### PR DESCRIPTION
Add [Rave Names](https://rave.domains/) resolution into the `useLookupAddress` hook.

The hook will by default resolve to ENS, but if a second optional parameter is set to `true`, the hook will resolve to a Rave Name.