### PR TITLE
🔴 Add Optimism Sepolia testnet

### DIFF
--- a/.changeset/great-drinks-help.md
+++ b/.changeset/great-drinks-help.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+Added 'Optimism Sepolia' testnet

--- a/packages/core/src/model/chain/optimism.ts
+++ b/packages/core/src/model/chain/optimism.ts
@@ -39,6 +39,25 @@ export const OptimismGoerli: Chain = {
   getExplorerTransactionLink: getTransactionLink(testnetGoerliExplorerUrl),
 }
 
+const testnetSepoliaExplorerUrl = 'https://sepolia-optimism.etherscan.io'
+
+export const OptimismSepolia: Chain = {
+  chainId: 11155420,
+  chainName: 'Optimism Sepolia',
+  isTestChain: true,
+  isLocalChain: false,
+  multicallAddress: '0xcA11bde05977b3631167028862bE2a173976CA11',
+  rpcUrl: 'https://sepolia.optimism.io',
+  nativeCurrency: {
+    name: 'Sepolia Ether',
+    symbol: 'ETH',
+    decimals: 18,
+  },
+  blockExplorerUrl: testnetSepoliaExplorerUrl,
+  getExplorerAddressLink: getAddressLink(testnetSepoliaExplorerUrl),
+  getExplorerTransactionLink: getTransactionLink(testnetSepoliaExplorerUrl),
+}
+
 const optimismExplorerUrl = 'https://optimistic.etherscan.io'
 
 export const Optimism: Chain = {
@@ -61,5 +80,6 @@ export const Optimism: Chain = {
 export default {
   OptimismKovan,
   OptimismGoerli,
+  OptimismSepolia,
   Optimism,
 }


### PR DESCRIPTION
Optimism Goerli testnet is really not in use these days and many rpc providers (like alchemy) don't even support it. So, thought of adding `Optimism Sepolia`. Really got to create my own `chain.ts` file for that particular testnet use. Well, now it be easy for others!

Got the information related to this testnet from these two links -> [Optimism Official site](https://chainid.link/?network=op-sepolia) and [Multicall Address for sepolia](https://github.com/mds1/multicall/blob/main/deployments.json)

Thanks