### PR TITLE
💅 Update coingecko test

### DIFF
--- a/packages/coingecko/src/hooks/useCoingeckoTokenPrices.test.tsx
+++ b/packages/coingecko/src/hooks/useCoingeckoTokenPrices.test.tsx
@@ -2,11 +2,7 @@ import { renderHook } from '@testing-library/react-hooks'
 import { useCoingeckoTokenPrices } from './useCoingeckoPrices'
 import { expect } from 'chai'
 
-const ADDRESSES = [
-  '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
-  '0xe41d2489571d322189246dafa5ebde1f4699f498',
-  '0xf5dce57282a584d2746faf1593d3121fcac444dc',
-]
+const ADDRESSES = ['0x0d8775f648430679a709e98d2b0cb6250d2887ef']
 
 describe('useCoingeckoTokenPrices', () => {
   it('works', async () => {
@@ -15,7 +11,7 @@ describe('useCoingeckoTokenPrices', () => {
     await waitForNextUpdate()
     expect(result.error).to.be.undefined
     expect(result.current).to.be.an('array')
-    expect(result.current?.length).to.eq(3)
+    expect(result.current?.length).to.eq(1)
     expect(result.current![0]).to.be.a('number')
   })
 })


### PR DESCRIPTION
Coingecko allows fetching only 1 token per call now so it has to be changed in test